### PR TITLE
test: add portfolio unit test suite and fix issues it surfaced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    name: Build & Test (coverage)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Run unit tests with coverage
+        run: npm run test:ci
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          if-no-files-found: warn

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,51 @@
+// Karma configuration file
+// https://karma-runner.github.io/6.4/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma'),
+    ],
+    client: {
+      jasmine: {
+        // Random execution order surfaces hidden inter-test coupling.
+        random: true,
+      },
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true, // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ],
+    },
+    reporters: ['progress', 'kjhtml'],
+    browsers: ['Chrome'],
+    customLaunchers: {
+      // Used in CI where there is no display server and Chrome runs as root.
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: [
+          '--no-sandbox',
+          '--disable-gpu',
+          '--disable-dev-shm-usage',
+          '--headless',
+          '--remote-debugging-port=9222',
+        ],
+      },
+    },
+    restartOnFileChange: true,
+  });
+};

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:prod": "ng build --base-href /Portfolio/ --configuration production",
     "deploy": "npm run build && touch docs/.nojekyll && cp src/404.html docs/404.html",
     "test": "ng test",
+    "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCI --code-coverage",
     "lint": "ng lint",
     "e2e": "ng e2e"
   },

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 import { AppComponent } from './app.component';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 
@@ -8,6 +10,12 @@ describe('AppComponent', () => {
       imports: [
         AppComponent,
         HttpClientTestingModule
+      ],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { fragment: of(null), params: of({}), queryParams: of({}) },
+        },
       ],
     }).compileComponents();
   }));

--- a/src/app/config/api-config.spec.ts
+++ b/src/app/config/api-config.spec.ts
@@ -1,0 +1,84 @@
+import {
+  API_CONFIG,
+  AI_API_URL,
+  TTS_API_URL,
+  STREAMING_VOICE_API_URL,
+  createOpenAiProxyRequest,
+  getAiResponseText,
+} from './api-config';
+
+describe('api-config', () => {
+  describe('getUrl / exported URLs', () => {
+    it('joins the base URL with an endpoint', () => {
+      expect(API_CONFIG.getUrl('/api/v1/test')).toBe(`${API_CONFIG.BASE_URL}/api/v1/test`);
+    });
+
+    it('exposes fully-qualified URLs derived from the config', () => {
+      expect(AI_API_URL).toBe(API_CONFIG.getUrl(API_CONFIG.ENDPOINTS.AI_GENERIC));
+      expect(TTS_API_URL).toBe(API_CONFIG.getUrl(API_CONFIG.ENDPOINTS.TEXT_TO_SPEECH));
+      expect(STREAMING_VOICE_API_URL).toBe(API_CONFIG.getUrl(API_CONFIG.ENDPOINTS.STREAMING_VOICE));
+    });
+
+    it('uses an https base URL (no plaintext transport)', () => {
+      expect(API_CONFIG.BASE_URL.startsWith('https://')).toBeTrue();
+    });
+  });
+
+  describe('createOpenAiProxyRequest', () => {
+    const messages = [
+      { role: 'system' as const, content: 'you are nova' },
+      { role: 'user' as const, content: 'hi' },
+    ];
+
+    it('wraps messages with the default model and token budget', () => {
+      const req = createOpenAiProxyRequest(messages);
+      expect(req.model).toBe('gpt-5-nano');
+      expect(req.maxTokens).toBe(1000);
+      expect(req.messages).toBe(messages);
+    });
+
+    it('honours a custom maxTokens value', () => {
+      expect(createOpenAiProxyRequest(messages, 256).maxTokens).toBe(256);
+    });
+
+    it('supports an empty conversation', () => {
+      expect(createOpenAiProxyRequest([]).messages).toEqual([]);
+    });
+  });
+
+  describe('getAiResponseText', () => {
+    it('reads the OpenAI-style choices path first', () => {
+      const res = { data: { choices: [{ message: { content: '  hello  ' } }] } };
+      expect(getAiResponseText(res)).toBe('hello');
+    });
+
+    it('falls back through the supported shapes in priority order', () => {
+      expect(getAiResponseText({ choices: [{ message: { content: 'top-level choice' } }] })).toBe('top-level choice');
+      expect(getAiResponseText({ data: { response: 'data.response' } })).toBe('data.response');
+      expect(getAiResponseText({ data: { answer: 'data.answer' } })).toBe('data.answer');
+      expect(getAiResponseText({ message: 'bare message' })).toBe('bare message');
+      expect(getAiResponseText({ content: 'bare content' })).toBe('bare content');
+    });
+
+    it('prefers the deeper choices path over a bare content field', () => {
+      const res = {
+        data: { choices: [{ message: { content: 'preferred' } }] },
+        content: 'ignored',
+      };
+      expect(getAiResponseText(res)).toBe('preferred');
+    });
+
+    it('skips empty/whitespace candidates and returns the first usable one', () => {
+      const res = { data: { response: '   ' }, message: 'usable' };
+      expect(getAiResponseText(res)).toBe('usable');
+    });
+
+    it('returns null when nothing usable is present', () => {
+      expect(getAiResponseText({})).toBeNull();
+      expect(getAiResponseText(null)).toBeNull();
+      expect(getAiResponseText(undefined)).toBeNull();
+      expect(getAiResponseText({ data: { choices: [] } })).toBeNull();
+      expect(getAiResponseText({ message: 123 })).toBeNull();
+    });
+  });
+});

--- a/src/app/config/profile-links.spec.ts
+++ b/src/app/config/profile-links.spec.ts
@@ -1,0 +1,62 @@
+import {
+  SOCIAL_LINKS,
+  DOCUMENT_LINKS,
+  PROJECT_LINKS,
+  BLOG_LINKS,
+  PACKAGE_LINKS,
+  CONTACT_LINKS,
+  ANALYTICS_LINKS,
+  COMPANY_LINKS,
+} from './profile-links';
+
+describe('profile-links', () => {
+  const collectUrls = (obj: Record<string, string>) => Object.values(obj);
+  const allLinkGroups = [SOCIAL_LINKS, DOCUMENT_LINKS, PROJECT_LINKS, BLOG_LINKS, PACKAGE_LINKS, ANALYTICS_LINKS, COMPANY_LINKS];
+
+  it('exposes only well-formed http(s) URLs across every link group', () => {
+    allLinkGroups.forEach(group => {
+      collectUrls(group as Record<string, string>).forEach(url => {
+        expect(url).withContext(url).toMatch(/^https?:\/\/.+/);
+        expect(() => new URL(url)).withContext(url).not.toThrow();
+      });
+    });
+  });
+
+  it('has no empty link values', () => {
+    allLinkGroups.forEach(group => {
+      collectUrls(group as Record<string, string>).forEach(url => {
+        expect(url.trim().length).toBeGreaterThan(0);
+      });
+    });
+  });
+
+  it('points social links at the expected platforms', () => {
+    expect(SOCIAL_LINKS.linkedin).toContain('linkedin.com');
+    expect(SOCIAL_LINKS.github).toContain('github.com');
+    expect(SOCIAL_LINKS.stackOverflow).toContain('stackoverflow.com');
+  });
+
+  it('uses a valid contact email', () => {
+    expect(CONTACT_LINKS.email).toMatch(/^[^@\s]+@[^@\s]+\.[^@\s]+$/);
+  });
+
+  it('keeps every company link pointing at its official domain', () => {
+    expect(COMPANY_LINKS.salesforce).toContain('salesforce.com');
+    expect(COMPANY_LINKS.games24x7).toContain('games24x7.com');
+    expect(COMPANY_LINKS.walmart).toContain('walmart.com');
+    expect(COMPANY_LINKS.extramarks).toContain('extramarks.com');
+  });
+
+  it('exposes npm/maven package pages for each open-source project', () => {
+    expect(PACKAGE_LINKS.nodeActuatorLite).toContain('npmjs.com/package/node-actuator-lite');
+    expect(PACKAGE_LINKS.gitHistoryUi).toContain('npmjs.com/package/git-history-ui');
+    expect(PACKAGE_LINKS.eli5).toContain('sonatype.com');
+  });
+
+  it('contains no duplicate URLs within a single group', () => {
+    allLinkGroups.forEach(group => {
+      const urls = collectUrls(group as Record<string, string>);
+      expect(new Set(urls).size).withContext(JSON.stringify(group)).toBe(urls.length);
+    });
+  });
+});

--- a/src/app/profile/about/about.component.spec.ts
+++ b/src/app/profile/about/about.component.spec.ts
@@ -8,7 +8,7 @@ describe('AboutComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [AboutComponent]
+      imports: [AboutComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/avatar-3d/avatar-3d.component.spec.ts
+++ b/src/app/profile/avatar-3d/avatar-3d.component.spec.ts
@@ -8,9 +8,8 @@ describe('Avatar3dComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Avatar3dComponent]
-    })
-    .compileComponents();
+      imports: [Avatar3dComponent],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(Avatar3dComponent);
     component = fixture.componentInstance;
@@ -19,5 +18,18 @@ describe('Avatar3dComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('degrades gracefully when WebGL is unavailable (headless CI)', () => {
+    // No real GPU in CI: the component should flag WebGL as unavailable and
+    // stop showing the loading state rather than throwing on renderer init.
+    expect(component.webglAvailable).toBeFalse();
+    expect(component.isLoading).toBeFalse();
+  });
+
+  it('cleans up timers/listeners on destroy even if the 3D scene never booted', () => {
+    const removeSpy = spyOn(window, 'removeEventListener').and.callThrough();
+    expect(() => component.ngOnDestroy()).not.toThrow();
+    expect(removeSpy).toHaveBeenCalledWith('resize', jasmine.any(Function));
   });
 });

--- a/src/app/profile/avatar-3d/avatar-3d.component.ts
+++ b/src/app/profile/avatar-3d/avatar-3d.component.ts
@@ -51,6 +51,8 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
   private model!: THREE.Group;
   private animationFrameId?: number;
   private boundResizeHandler = () => this.onWindowResize();
+  /** False when the browser/environment cannot create a WebGL context (e.g. headless CI). */
+  public webglAvailable = true;
 
   // Chat functionality
   public isChatOpen = false;
@@ -89,10 +91,14 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.initThreeJS();
+    if (!this.initThreeJS()) {
+      // WebGL unavailable — skip the 3D scene but keep the chat usable.
+      this.isLoading = false;
+      return;
+    }
     this.loadAvatar();
     this.animate();
-    
+
   }
 
   ngOnDestroy(): void {
@@ -107,8 +113,17 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
     this.stopSpeech();
   }
 
-  private initThreeJS(): void {
+  private initThreeJS(): boolean {
     const canvas = this.canvasRef.nativeElement;
+
+    // Bail out early if the environment has no WebGL support (e.g. headless CI,
+    // older browsers, GPU disabled). Three.js would otherwise throw on renderer
+    // construction and break the whole component.
+    const probe = canvas.getContext('webgl2') || canvas.getContext('webgl');
+    if (!probe) {
+      this.webglAvailable = false;
+      return false;
+    }
 
     // Scene
     this.scene = new THREE.Scene();
@@ -124,11 +139,16 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
     this.camera.position.set(0, 1, 2);
 
     // Renderer
-    this.renderer = new THREE.WebGLRenderer({
-      canvas: canvas,
-      antialias: true,
-      alpha: true
-    });
+    try {
+      this.renderer = new THREE.WebGLRenderer({
+        canvas: canvas,
+        antialias: true,
+        alpha: true
+      });
+    } catch {
+      this.webglAvailable = false;
+      return false;
+    }
     this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
     this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
     this.renderer.shadowMap.enabled = true;
@@ -159,6 +179,7 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
 
     // Handle window resize
     window.addEventListener('resize', this.boundResizeHandler);
+    return true;
   }
 
   private loadAvatar(): void {
@@ -240,8 +261,11 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
   }
 
   private animate(): void {
+    if (!this.renderer) {
+      return;
+    }
     this.animationFrameId = requestAnimationFrame(() => this.animate());
-    
+
     this.controls.update();
     this.renderer.render(this.scene, this.camera);
   }
@@ -484,6 +508,9 @@ export class Avatar3dComponent implements OnInit, OnDestroy {
   }
 
   private onWindowResize(): void {
+    if (!this.renderer) {
+      return;
+    }
     const canvas = this.canvasRef.nativeElement;
     this.camera.aspect = canvas.clientWidth / canvas.clientHeight;
     this.camera.updateProjectionMatrix();

--- a/src/app/profile/contact/contact.component.spec.ts
+++ b/src/app/profile/contact/contact.component.spec.ts
@@ -8,7 +8,7 @@ describe('ContactComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ContactComponent]
+      imports: [ContactComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/education/education.component.spec.ts
+++ b/src/app/profile/education/education.component.spec.ts
@@ -8,7 +8,7 @@ describe('EducationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [EducationComponent]
+      imports: [EducationComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/experience/experience.component.spec.ts
+++ b/src/app/profile/experience/experience.component.spec.ts
@@ -8,7 +8,7 @@ describe('ExperienceComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ExperienceComponent]
+      imports: [ExperienceComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/footer/footer.component.spec.ts
+++ b/src/app/profile/footer/footer.component.spec.ts
@@ -8,7 +8,7 @@ describe('FooterComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [FooterComponent]
+      imports: [FooterComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/header/header.component.spec.ts
+++ b/src/app/profile/header/header.component.spec.ts
@@ -8,7 +8,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [HeaderComponent]
+      imports: [HeaderComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/intro/intro.component.spec.ts
+++ b/src/app/profile/intro/intro.component.spec.ts
@@ -8,7 +8,7 @@ describe('IntroComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [IntroComponent]
+      imports: [IntroComponent]
     })
       .compileComponents();
   }));

--- a/src/app/profile/profile.component.spec.ts
+++ b/src/app/profile/profile.component.spec.ts
@@ -1,25 +1,38 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of } from 'rxjs';
 
-import {ProfileComponent} from './profile.component';
+import { ProfileComponent } from './profile.component';
 
 describe('ProfileComponent', () => {
   let component: ProfileComponent;
   let fixture: ComponentFixture<ProfileComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [ProfileComponent]
-    })
-      .compileComponents();
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileComponent, HttpClientTestingModule],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: { fragment: of(null), params: of({}), queryParams: of({}) },
+        },
+      ],
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(ProfileComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    // No detectChanges(): rendering the full profile tree boots a Three.js
+    // WebGLRenderer (Avatar3d). We exercise the component class directly here;
+    // the full render path is covered by AppComponent's integration spec.
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('subscribes to the route fragment on init and cleans up on destroy', () => {
+    component.ngOnInit();
+    expect(() => component.ngOnDestroy()).not.toThrow();
   });
 });

--- a/src/app/profile/publications/publications.component.scss
+++ b/src/app/profile/publications/publications.component.scss
@@ -115,6 +115,12 @@
   opacity: 0.85;
 }
 
+.world-salesforce {
+  background: rgba(56, 189, 248, 0.14);
+  border: 1px solid rgba(56, 189, 248, 0.34);
+  color: #7dd3fc;
+}
+
 .world-games {
   background: rgba(239, 68, 68, 0.14);
   border: 1px solid rgba(239, 68, 68, 0.32);

--- a/src/app/profile/publications/publications.component.spec.ts
+++ b/src/app/profile/publications/publications.component.spec.ts
@@ -1,19 +1,17 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import {PublicationsComponent} from './publications.component';
+import { PublicationsComponent } from './publications.component';
+import { COMPANY_LINKS } from '../../config/profile-links';
 
 describe('PublicationsComponent', () => {
   let component: PublicationsComponent;
   let fixture: ComponentFixture<PublicationsComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [PublicationsComponent]
-    })
-      .compileComponents();
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PublicationsComponent],
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(PublicationsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -21,5 +19,86 @@ describe('PublicationsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('open-source catalogue', () => {
+    it('initialises filters with "All" first plus every distinct category', () => {
+      expect(component.availableCategories[0]).toBe('All');
+      const distinct = new Set(component.openSourceProjects.map(p => p.category));
+      distinct.forEach(cat => expect(component.availableCategories).toContain(cat));
+      expect(component.availableCategories.length).toBe(distinct.size + 1);
+    });
+
+    it('shows every project by default', () => {
+      expect(component.selectedCategory).toBe('All');
+      expect(component.filteredProjects.length).toBe(component.openSourceProjects.length);
+    });
+
+    it('filters projects down to a single category', () => {
+      component.filterByCategory('Maven Central');
+      expect(component.selectedCategory).toBe('Maven Central');
+      expect(component.filteredProjects.length).toBeGreaterThan(0);
+      expect(component.filteredProjects.every(p => p.category === 'Maven Central')).toBeTrue();
+    });
+
+    it('restores the full list when filtering back to "All"', () => {
+      component.filterByCategory('NPM');
+      component.filterByCategory('All');
+      expect(component.filteredProjects.length).toBe(component.openSourceProjects.length);
+    });
+
+    it('gives every project a non-empty link, title and category', () => {
+      component.openSourceProjects.forEach(p => {
+        expect(p.title.trim().length).toBeGreaterThan(0);
+        expect(p.link).toMatch(/^https?:\/\//);
+        expect(['NPM', 'Maven Central', 'GitHub', 'PyPI']).toContain(p.category);
+      });
+    });
+
+    it('has unique project ids', () => {
+      const ids = component.openSourceProjects.map(p => p.id);
+      expect(new Set(ids).size).toBe(ids.length);
+    });
+  });
+
+  describe('On-call AI Agent quest card', () => {
+    it('renders the Salesforce quest card linked to the official site', () => {
+      const card: HTMLElement = fixture.nativeElement.querySelector('.salesforce-card');
+      expect(card).toBeTruthy();
+
+      const badge = card.querySelector('a.world-salesforce') as HTMLAnchorElement;
+      expect(badge).toBeTruthy();
+      expect(badge.getAttribute('href')).toBe(COMPANY_LINKS.salesforce);
+      expect(badge.getAttribute('target')).toBe('_blank');
+      expect(badge.getAttribute('rel')).toContain('noopener');
+    });
+
+    it('shows the On-call AI Agent quest name and key abilities', () => {
+      const card: HTMLElement = fixture.nativeElement.querySelector('.salesforce-card');
+      expect(card.textContent).toContain('On-call AI Agent');
+      ['RAG', 'Bedrock', 'MCP Servers', 'Spring AI'].forEach(ability => {
+        expect(card.textContent).toContain(ability);
+      });
+    });
+
+    it('exposes the company links to the template', () => {
+      expect(component.companyLinks).toBe(COMPANY_LINKS);
+    });
+  });
+
+  describe('RRE deep dive data', () => {
+    it('exposes architecture nodes, stats and tech for the boss fight', () => {
+      expect(component.rreArchNodes.length).toBeGreaterThan(0);
+      expect(component.rreStats.length).toBeGreaterThan(0);
+      expect(component.rreTech.length).toBeGreaterThan(0);
+      component.rreArchNodes.forEach(n => {
+        expect(n.label.trim().length).toBeGreaterThan(0);
+        expect(n.color).toMatch(/^#/);
+      });
+    });
+
+    it('defaults the deep dive panel to collapsed', () => {
+      expect(component.showRREDeepDive).toBeFalse();
+    });
   });
 });

--- a/src/app/profile/skills/skills.component.html
+++ b/src/app/profile/skills/skills.component.html
@@ -34,6 +34,60 @@
       </div>
     </div>
 
+    <!-- ══════ ARCHITECTURE MAP (system mode) ══════ -->
+    @if (systemMode) {
+      <div class="arch-map">
+        <div class="arch-flow-hint">
+          <span class="arch-flow-hint-pill">▼ A REQUEST FLOWS DOWN THE STACK ▼</span>
+        </div>
+
+        @for (layer of architectureLayers; track layer.id; let lastLayer = $last) {
+          <div class="arch-layer" [style.--layer-color]="layer.color">
+            <div class="arch-layer-rail"></div>
+            <div class="arch-layer-head">
+              <span class="arch-layer-icon">{{ layer.icon }}</span>
+              <div class="arch-layer-title">
+                <span class="arch-layer-name">{{ layer.name }}</span>
+                <span class="arch-layer-role">{{ layer.role }}</span>
+              </div>
+              <span class="arch-layer-count">{{ layer.skills.length }}</span>
+            </div>
+
+            <div class="arch-nodes">
+              @for (skill of layer.skills; track skill.name) {
+                <div class="arch-node"
+                     [ngClass]="{
+                       'arch-node--boss': skill.level === 'primary',
+                       'arch-node--flow': isSystemFlowNode(skill)
+                     }"
+                     [attr.title]="skill.tooltip">
+                  @if (isSystemFlowNode(skill)) {
+                    <span class="arch-flow-num">{{ getSystemFlowIndex(skill) + 1 }}</span>
+                  }
+                  <span class="arch-node-name">{{ getDisplayName(skill) }}</span>
+                  <span class="arch-node-xp">{{ skill.proficiency }}</span>
+                </div>
+              }
+            </div>
+          </div>
+
+          @if (!lastLayer) {
+            <div class="arch-pipe" aria-hidden="true">
+              <span class="arch-pipe-dot"></span>
+              <span class="arch-pipe-dot"></span>
+              <span class="arch-pipe-dot"></span>
+            </div>
+          }
+        }
+
+        <div class="arch-legend">
+          <span class="arch-legend-item"><span class="arch-legend-key arch-legend-key--boss">★</span> Boss skill</span>
+          <span class="arch-legend-item"><span class="arch-legend-key arch-legend-key--flow">1</span> Request path</span>
+          <span class="arch-legend-item">XP&nbsp;=&nbsp;proficiency</span>
+        </div>
+      </div>
+    } @else {
+
     <!-- Category groups -->
     @for (constellation of constellations; track constellation.id) {
       <div class="category-group">
@@ -141,5 +195,6 @@
         <span class="legend-label">Support Tool</span>
       </div>
     </div>
+    }
   </div>
 </div>

--- a/src/app/profile/skills/skills.component.scss
+++ b/src/app/profile/skills/skills.component.scss
@@ -506,6 +506,272 @@
   white-space: nowrap;
 }
 
+/* ══════ Architecture map (system mode) ══════ */
+.arch-map {
+  max-width: 60rem;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  animation: detailSlideIn 0.35s ease-out;
+}
+
+.arch-flow-hint {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1.4rem;
+}
+
+.arch-flow-hint-pill {
+  font-family: var(--font-pixel);
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  color: #fca5a5;
+  padding: 0.5rem 1rem;
+  border: 1px solid rgba(239, 68, 68, 0.32);
+  border-radius: 999px;
+  background: rgba(239, 68, 68, 0.08);
+  animation: archHintPulse 2.4s ease-in-out infinite;
+}
+
+@keyframes archHintPulse {
+  0%, 100% { opacity: 0.55; transform: translateY(0); }
+  50%      { opacity: 1;    transform: translateY(2px); }
+}
+
+.arch-layer {
+  position: relative;
+  padding: 1.1rem 1.25rem 1.2rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid color-mix(in srgb, var(--layer-color) 40%, transparent);
+  background:
+    linear-gradient(135deg,
+      color-mix(in srgb, var(--layer-color) 12%, transparent) 0%,
+      rgba(255, 255, 255, 0.025) 60%);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.arch-layer:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 14px 38px color-mix(in srgb, var(--layer-color) 22%, transparent);
+}
+
+.arch-layer-rail {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: 4px;
+  background: var(--layer-color);
+  box-shadow: 0 0 14px var(--layer-color);
+}
+
+.arch-layer-head {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.9rem;
+}
+
+.arch-layer-icon {
+  flex-shrink: 0;
+  width: 2.4rem;
+  height: 2.4rem;
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--layer-color) 40%, transparent);
+  background: color-mix(in srgb, var(--layer-color) 14%, rgba(0, 0, 0, 0.2));
+}
+
+.arch-layer-title {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.arch-layer-name {
+  font-family: var(--font-display);
+  font-size: 1.02rem;
+  font-weight: 800;
+  color: var(--layer-color);
+  letter-spacing: -0.01em;
+}
+
+.arch-layer-role {
+  font-size: 0.74rem;
+  color: var(--text-muted);
+  line-height: 1.35;
+}
+
+.arch-layer-count {
+  flex-shrink: 0;
+  margin-left: auto;
+  align-self: flex-start;
+  font-family: var(--font-pixel);
+  font-size: 0.55rem;
+  padding: 0.3rem 0.55rem;
+  border-radius: 8px;
+  color: var(--layer-color);
+  border: 1px solid color-mix(in srgb, var(--layer-color) 35%, transparent);
+  background: color-mix(in srgb, var(--layer-color) 10%, transparent);
+}
+
+.arch-nodes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.arch-node {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.8rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.03);
+  cursor: default;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.arch-node:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--layer-color) 55%, transparent);
+  background: color-mix(in srgb, var(--layer-color) 10%, rgba(255, 255, 255, 0.03));
+  box-shadow: 0 6px 18px color-mix(in srgb, var(--layer-color) 22%, transparent);
+}
+
+.arch-node-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.arch-node-xp {
+  font-family: var(--font-display);
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--layer-color);
+  opacity: 0.85;
+
+  &::after { content: ' XP'; font-size: 0.6rem; opacity: 0.7; }
+}
+
+.arch-node--boss {
+  border-color: rgba(255, 213, 79, 0.42);
+  background: rgba(255, 200, 80, 0.07);
+
+  &::after {
+    content: '\2605';
+    position: absolute;
+    top: -0.5rem;
+    right: -0.4rem;
+    font-size: 0.7rem;
+    color: #FFD54F;
+    text-shadow: 0 0 6px rgba(255, 213, 79, 0.7);
+  }
+
+  .arch-node-name { color: #fde68a; }
+}
+
+.arch-node--flow {
+  border-color: rgba(76, 175, 80, 0.5);
+  background: rgba(76, 175, 80, 0.1);
+  box-shadow: 0 0 14px rgba(76, 175, 80, 0.14);
+}
+
+.arch-flow-num {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: rgba(76, 175, 80, 0.92);
+  color: #04210a;
+  font-size: 0.66rem;
+  font-weight: 800;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 0 8px rgba(76, 175, 80, 0.55);
+}
+
+.arch-pipe {
+  position: relative;
+  height: 2.2rem;
+  width: 4px;
+  margin: 0.15rem auto;
+  border-radius: 2px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.05), rgba(148, 163, 184, 0.22), rgba(148, 163, 184, 0.05));
+}
+
+.arch-pipe-dot {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  width: 7px;
+  height: 7px;
+  margin-left: -3.5px;
+  border-radius: 50%;
+  background: #fbbf24;
+  box-shadow: 0 0 8px rgba(251, 191, 36, 0.7);
+  animation: archPipeFlow 1.6s linear infinite;
+
+  &:nth-child(2) { animation-delay: 0.53s; }
+  &:nth-child(3) { animation-delay: 1.06s; }
+}
+
+@keyframes archPipeFlow {
+  0%   { transform: translateY(-2px); opacity: 0; }
+  20%  { opacity: 1; }
+  80%  { opacity: 1; }
+  100% { transform: translateY(2.2rem); opacity: 0; }
+}
+
+.arch-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.2rem;
+  margin-top: 1.6rem;
+  padding: 0.7rem 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.arch-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.76rem;
+  color: rgba(220, 232, 214, 0.72);
+}
+
+.arch-legend-key {
+  display: grid;
+  place-items: center;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 6px;
+  font-size: 0.62rem;
+  font-weight: 800;
+
+  &--boss { color: #FFD54F; background: rgba(255, 200, 80, 0.12); border: 1px solid rgba(255, 213, 79, 0.35); }
+  &--flow { color: #04210a; background: rgba(76, 175, 80, 0.9); border-radius: 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arch-flow-hint-pill,
+  .arch-pipe-dot { animation: none; }
+  .arch-pipe-dot { opacity: 0.9; top: 40%; }
+}
+
 /* ── Responsive ──────────────────────────────────────── */
 @media (max-width: 768px) {
   .rpg-skills-section { padding: 4rem 0; }
@@ -522,6 +788,8 @@
   }
   .legend-item { padding: 0; }
   .legend-divider { width: 100%; height: 1px; }
+
+  .arch-legend { gap: 0.8rem 1.2rem; }
 }
 
 @media (max-width: 480px) {
@@ -529,4 +797,9 @@
   .section-title { font-size: 2rem; }
   .skills-hud { grid-template-columns: 1fr; }
   .skill-card-grid { grid-template-columns: 1fr; }
+
+  .arch-layer-role { display: none; }
+  .arch-layer { padding: 0.95rem 1rem 1rem 1.25rem; }
+  .arch-node { padding: 0.45rem 0.65rem; }
+  .arch-node-name { font-size: 0.78rem; }
 }

--- a/src/app/profile/skills/skills.component.ts
+++ b/src/app/profile/skills/skills.component.ts
@@ -51,9 +51,13 @@ export class SkillsComponent implements OnInit {
     'Microservices': 'Service Mesh',
     'Spring Boot': 'API Framework',
     'High Level Design': 'System Design',
+    'Generative AI': 'GenAI Core',
     'LLM': 'AI Engine',
     'RAG': 'Knowledge Retrieval',
     'VectorDB': 'Embedding Store',
+    'Semantic Caching': 'Semantic Cache',
+    'MCP Servers': 'Tool Gateway',
+    'Bedrock': 'Model Host',
     'Elasti-Cache': 'Cache Cluster',
     'RabbitMQ': 'Task Queue',
     'AmazonSQS': 'Managed Queue',
@@ -64,6 +68,29 @@ export class SkillsComponent implements OnInit {
   readonly systemModeFlow = [
     'Spring Boot', 'Microservices', 'Kafka', 'Redis', 'MySQL'
   ];
+
+  // Ordered top-to-bottom architecture stack used by the graphical "Architecture route" view.
+  // Each entry maps a constellation id to a tier icon + a one-line role for the layer.
+  private readonly archLayerMeta: { id: string; icon: string; role: string }[] = [
+    { id: 'languages',    icon: '\u2699\uFE0F', role: 'Runtime & languages powering every service' },
+    { id: 'frameworks',   icon: '\uD83E\uDDE9', role: 'API frameworks that expose the services' },
+    { id: 'architecture', icon: '\uD83C\uDFDB\uFE0F', role: 'How services are decomposed & scaled' },
+    { id: 'queues',       icon: '\uD83D\uDCE8', role: 'Async backbone moving events between services' },
+    { id: 'cache',        icon: '\u26A1', role: 'Hot-path reads & low-latency shared state' },
+    { id: 'databases',    icon: '\uD83D\uDDC4\uFE0F', role: 'Source-of-truth & specialised data stores' },
+    { id: 'ai',           icon: '\uD83E\uDD16', role: 'Generative AI layer grounded on the platform' },
+    { id: 'core',         icon: '\uD83E\uDDE0', role: 'Fundamentals underpinning the whole stack' },
+  ];
+
+  get architectureLayers(): { id: string; name: string; color: string; icon: string; role: string; skills: Skill[] }[] {
+    return this.archLayerMeta
+      .map(meta => {
+        const c = this.constellations.find(x => x.id === meta.id);
+        if (!c) return null;
+        return { id: c.id, name: c.name, color: c.color, icon: meta.icon, role: meta.role, skills: c.skills };
+      })
+      .filter((layer): layer is { id: string; name: string; color: string; icon: string; role: string; skills: Skill[] } => layer !== null);
+  }
 
   ngOnInit(): void {
     this.buildConstellations();
@@ -111,10 +138,13 @@ export class SkillsComponent implements OnInit {
       {
         id: 'ai', name: 'AI / ML', color: '#F48FB1', glowColor: 'rgba(244,143,177,0.6)',
         skills: [
-          { name: 'Generative AI', proficiency: 90, level: 'primary',   tooltip: 'Cut manual triage effort by 50%',      x: 38, y: 46 },
-          { name: 'LLM',           proficiency: 90, level: 'primary',   tooltip: 'API integration · tool-calling',       x: 54, y: 40 },
-          { name: 'RAG',           proficiency: 92, level: 'secondary', tooltip: 'Rerank pipelines · less hallucination', x: 42, y: 60 },
-          { name: 'VectorDB',      proficiency: 90, level: 'secondary', tooltip: 'Pinecone · pgvector · semantic search', x: 60, y: 56 },
+          { name: 'Generative AI',    proficiency: 90, level: 'primary',   tooltip: 'Cut manual triage effort by 50%',      x: 38, y: 46 },
+          { name: 'LLM',              proficiency: 90, level: 'primary',   tooltip: 'API integration · tool-calling',       x: 54, y: 40 },
+          { name: 'RAG',              proficiency: 92, level: 'secondary', tooltip: 'Rerank pipelines · less hallucination', x: 42, y: 60 },
+          { name: 'VectorDB',         proficiency: 90, level: 'secondary', tooltip: 'Pinecone · pgvector · semantic search', x: 60, y: 56 },
+          { name: 'Semantic Caching', proficiency: 89, level: 'secondary', tooltip: 'Embedding cache · cut LLM cost & latency', x: 46, y: 70 },
+          { name: 'MCP Servers',      proficiency: 88, level: 'secondary', tooltip: 'Model Context Protocol · tool gateways', x: 64, y: 66 },
+          { name: 'Bedrock',          proficiency: 88, level: 'supporting', tooltip: 'AWS Bedrock · multi-model hosting',     x: 56, y: 74 },
         ]
       },
       {

--- a/src/app/profile/skills/skills.data.ts
+++ b/src/app/profile/skills/skills.data.ts
@@ -432,6 +432,69 @@ export const SKILL_DETAILS: Record<string, SkillDetail> = {
     relatedSkills: ['RAG', 'LLM', 'Generative AI']
   },
 
+  'Semantic Caching': {
+    description: 'Embedding-based caching for LLM workloads that serves answers to semantically similar prompts from cache instead of hitting the model, cutting cost and latency.',
+    experience: [
+      'Built a semantic cache that embeds incoming prompts and matches them against prior responses by similarity threshold',
+      'Tuned similarity thresholds, TTLs, and namespace partitioning to balance hit rate against staleness',
+      'Backed the cache with a vector store plus Redis for metadata and fast lookups',
+      'Added cache-hit/miss metrics and guardrails to avoid serving stale or low-confidence matches'
+    ],
+    projects: [
+      'Semantic cache layer in front of the on-call AI agent',
+      'Cost-reduction layer for high-traffic LLM endpoints',
+      'Prompt deduplication for repeated support questions'
+    ],
+    achievements: [
+      'Reduced LLM spend and tail latency by serving repeated and near-duplicate queries from cache',
+      'Kept answer quality high with confidence thresholds and selective invalidation',
+      'Sustained sub-second p95 on cached retrieval paths under production load'
+    ],
+    relatedSkills: ['RAG', 'VectorDB', 'Redis']
+  },
+
+  'MCP Servers': {
+    description: 'Hands-on experience exposing tools and data to LLM agents through the Model Context Protocol, giving models a standard, secure way to call external systems.',
+    experience: [
+      'Built MCP servers that expose logs, code, and documentation as agent-callable tools',
+      'Designed tool schemas, auth, and input validation so agents call systems safely',
+      'Wired MCP tool-calling into RAG and agent workflows for grounded, action-capable responses',
+      'Handled timeouts, retries, and result shaping to keep tool calls reliable inside agent loops'
+    ],
+    projects: [
+      'MCP tool layer for the on-call AI agent (Splunk, GitHub, Drive, Confluence, Slack)',
+      'Standardized tool gateway shared across multiple agents',
+      'Secure data-access tools for grounded LLM workflows'
+    ],
+    achievements: [
+      'Let agents pull live context from many systems through one consistent protocol',
+      'Reduced bespoke integration glue by standardizing on MCP tool contracts',
+      'Improved agent safety with validated, scoped, auditable tool access'
+    ],
+    relatedSkills: ['LLM', 'RAG', 'Generative AI']
+  },
+
+  'Bedrock': {
+    description: 'Experience building on Amazon Bedrock to run multiple foundation models behind one managed API, with grounding, guardrails, and provider fallback.',
+    experience: [
+      'Integrated Bedrock-hosted models (including Anthropic Claude and Titan) into backend AI services',
+      'Used Bedrock alongside OpenAI and Anthropic APIs with a provider-abstraction and fallback layer',
+      'Applied Bedrock Guardrails and grounding to keep responses safe and on-policy',
+      'Tuned model selection, token budgets, and streaming for cost and latency targets'
+    ],
+    projects: [
+      'Multi-model inference layer for the on-call AI agent',
+      'Provider-agnostic LLM gateway with Bedrock as a backend',
+      'Grounded RCA summarization running across Bedrock, Anthropic, and OpenAI'
+    ],
+    achievements: [
+      'Ran production AI features across multiple model providers with graceful fallback',
+      'Kept inference within cost and latency budgets through model and token tuning',
+      'Improved safety and compliance using managed guardrails and grounding'
+    ],
+    relatedSkills: ['Generative AI', 'LLM', 'AWS']
+  },
+
   // ─── Queues ───────────────────────────────────────────
   'Kafka': {
     description: 'Strong working experience with Apache Kafka for event-driven systems, asynchronous processing, and real-time data pipelines.',

--- a/src/app/services/achievements.service.spec.ts
+++ b/src/app/services/achievements.service.spec.ts
@@ -1,0 +1,174 @@
+import { TestBed } from '@angular/core/testing';
+import { take } from 'rxjs/operators';
+import { AchievementsService, Achievement } from './achievements.service';
+
+describe('AchievementsService', () => {
+  const STORAGE_KEY = 'portfolio_achievements';
+  const VISIT_KEY = 'portfolio_visited';
+
+  const makeService = () => {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    return TestBed.inject(AchievementsService);
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date('2024-06-10T12:00:00')); // noon, not night owl
+  });
+
+  afterEach(() => {
+    jasmine.clock().uninstall();
+    localStorage.clear();
+  });
+
+  it('is created with all achievements locked on a first visit', () => {
+    const service = makeService();
+    expect(service.getTotalCount()).toBe(13);
+    expect(service.getUnlockedCount()).toBe(0);
+  });
+
+  describe('unlock', () => {
+    it('unlocks an achievement once and emits a toast', () => {
+      const service = makeService();
+      let toastFired = false;
+      service.toast$.pipe(take(1)).subscribe(t => {
+        toastFired = true;
+        expect(t.achievement.id).toBe('resume_reader');
+        expect(t.achievement.unlocked).toBeTrue();
+      });
+
+      expect(service.unlock('resume_reader')).toBeTrue();
+      expect(toastFired).toBeTrue();
+      expect(service.getUnlockedCount()).toBe(1);
+    });
+
+    it('is idempotent — a second unlock returns false and does not re-toast', () => {
+      const service = makeService();
+      let toastCount = 0;
+      service.toast$.subscribe(() => toastCount++);
+
+      expect(service.unlock('resume_reader')).toBeTrue();
+      expect(service.unlock('resume_reader')).toBeFalse();
+      expect(toastCount).toBe(1);
+    });
+
+    it('returns false for an unknown achievement id', () => {
+      const service = makeService();
+      expect(service.unlock('does_not_exist')).toBeFalse();
+      expect(service.getUnlockedCount()).toBe(0);
+    });
+
+    it('stamps unlockedAt and exposes it through the achievements$ stream', () => {
+      const service = makeService();
+      service.unlock('resume_reader');
+      const list = readStream(service);
+      const unlocked = list.find(a => a.id === 'resume_reader')!;
+      expect(unlocked.unlocked).toBeTrue();
+      expect(unlocked.unlockedAt).toBe(Date.parse('2024-06-10T12:00:00'));
+    });
+  });
+
+  describe('counter thresholds', () => {
+    it('only unlocks Skill Hunter after 5 skill expansions', () => {
+      const service = makeService();
+      for (let i = 0; i < 4; i++) service.trackSkillExpand();
+      expect(isUnlocked(service, 'skill_hunter')).toBeFalse();
+      service.trackSkillExpand();
+      expect(isUnlocked(service, 'skill_hunter')).toBeTrue();
+    });
+
+    it('only unlocks AI Whisperer after 3 questions', () => {
+      const service = makeService();
+      service.trackAiQuestion();
+      service.trackAiQuestion();
+      expect(isUnlocked(service, 'ai_whisperer')).toBeFalse();
+      service.trackAiQuestion();
+      expect(isUnlocked(service, 'ai_whisperer')).toBeTrue();
+    });
+
+    it('only unlocks Social Butterfly after 2 social clicks', () => {
+      const service = makeService();
+      service.trackSocialClick();
+      expect(isUnlocked(service, 'social_butterfly')).toBeFalse();
+      service.trackSocialClick();
+      expect(isUnlocked(service, 'social_butterfly')).toBeTrue();
+    });
+  });
+
+  describe('score and time gated achievements', () => {
+    it('unlocks Arcade Champion only at 500+', () => {
+      const service = makeService();
+      service.trackGameScore(499);
+      expect(isUnlocked(service, 'arcade_champion')).toBeFalse();
+      service.trackGameScore(500);
+      expect(isUnlocked(service, 'arcade_champion')).toBeTrue();
+    });
+
+    it('unlocks Speed Runner only within the first 30 seconds', () => {
+      const service = makeService();
+      jasmine.clock().tick(31_000);
+      service.trackSpeedRun();
+      expect(isUnlocked(service, 'speed_runner')).toBeFalse();
+    });
+
+    it('unlocks Speed Runner when triggered quickly', () => {
+      const service = makeService();
+      jasmine.clock().tick(5_000);
+      service.trackSpeedRun();
+      expect(isUnlocked(service, 'speed_runner')).toBeTrue();
+    });
+
+    it('unlocks Deep Diver after 3 minutes', () => {
+      const service = makeService();
+      expect(isUnlocked(service, 'deep_diver')).toBeFalse();
+      jasmine.clock().tick(3 * 60 * 1000);
+      expect(isUnlocked(service, 'deep_diver')).toBeTrue();
+    });
+  });
+
+  describe('contextual unlocks at construction', () => {
+    it('unlocks Welcome Back when a previous visit is recorded', () => {
+      localStorage.setItem(VISIT_KEY, '123');
+      const service = makeService();
+      expect(isUnlocked(service, 'returner')).toBeTrue();
+    });
+
+    it('unlocks Night Owl between midnight and 5am', () => {
+      jasmine.clock().mockDate(new Date('2024-06-10T02:30:00'));
+      const service = makeService();
+      expect(isUnlocked(service, 'night_owl')).toBeTrue();
+    });
+  });
+
+  describe('persistence', () => {
+    it('restores unlocked achievements from localStorage', () => {
+      const first = makeService();
+      first.unlock('resume_reader');
+      first.trackSkillExpand();
+
+      const reloaded = makeService();
+      expect(isUnlocked(reloaded, 'resume_reader')).toBeTrue();
+      // counter persisted: 4 more expansions should now cross the threshold
+      for (let i = 0; i < 4; i++) reloaded.trackSkillExpand();
+      expect(isUnlocked(reloaded, 'skill_hunter')).toBeTrue();
+    });
+
+    it('survives corrupted localStorage data without throwing', () => {
+      localStorage.setItem(STORAGE_KEY, '{not valid json');
+      expect(() => makeService()).not.toThrow();
+    });
+  });
+
+  // helpers -------------------------------------------------------
+  function readStream(service: AchievementsService): Achievement[] {
+    let snapshot: Achievement[] = [];
+    service.achievements$.pipe(take(1)).subscribe(a => (snapshot = a));
+    return snapshot;
+  }
+
+  function isUnlocked(service: AchievementsService, id: string): boolean {
+    return !!readStream(service).find(a => a.id === id)?.unlocked;
+  }
+});

--- a/src/app/services/audio.service.spec.ts
+++ b/src/app/services/audio.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { take } from 'rxjs/operators';
+import { AudioService } from './audio.service';
+
+describe('AudioService', () => {
+  const STORAGE_KEY = 'portfolio_sfx_enabled';
+
+  const makeService = () => {
+    TestBed.configureTestingModule({});
+    return TestBed.inject(AudioService);
+  };
+
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it('defaults to disabled when no preference is stored', () => {
+    const service = makeService();
+    expect(service.enabled).toBeFalse();
+    expect(latest(service)).toBeFalse();
+  });
+
+  it('restores the enabled preference from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    expect(makeService().enabled).toBeTrue();
+  });
+
+  it('toggles state and persists the new value', () => {
+    const service = makeService();
+    service.toggle();
+    expect(service.enabled).toBeTrue();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('true');
+
+    service.toggle();
+    expect(service.enabled).toBeFalse();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+
+  it('emits the toggled state through enabled$', () => {
+    const service = makeService();
+    const emissions: boolean[] = [];
+    service.enabled$.subscribe(v => emissions.push(v));
+    service.toggle();
+    service.toggle();
+    expect(emissions).toEqual([false, true, false]);
+  });
+
+  it('does nothing audible and never throws when disabled', () => {
+    const service = makeService();
+    expect(service.enabled).toBeFalse();
+    expect(() => {
+      service.play('coin');
+      service.play('levelUp');
+      service.play('click');
+    }).not.toThrow();
+  });
+
+  it('plays sound effects without throwing once enabled', () => {
+    const service = makeService();
+    service.toggle(); // enables + plays a click
+    expect(() => {
+      (['coin', 'levelUp', 'powerUp', 'pipe', 'jump', 'star', 'click'] as const)
+        .forEach(name => service.play(name));
+    }).not.toThrow();
+  });
+
+  function latest(service: AudioService): boolean {
+    let v = false;
+    service.enabled$.pipe(take(1)).subscribe(x => (v = x));
+    return v;
+  }
+});

--- a/src/app/services/scroll-xp.service.spec.ts
+++ b/src/app/services/scroll-xp.service.spec.ts
@@ -1,0 +1,121 @@
+import { TestBed } from '@angular/core/testing';
+import { take } from 'rxjs/operators';
+import { ScrollXpService, LevelUpEvent } from './scroll-xp.service';
+import { AchievementsService } from './achievements.service';
+
+describe('ScrollXpService', () => {
+  let service: ScrollXpService;
+  let achievements: jasmine.SpyObj<AchievementsService>;
+
+  beforeEach(() => {
+    achievements = jasmine.createSpyObj<AchievementsService>('AchievementsService', ['trackSpeedRun']);
+    TestBed.configureTestingModule({
+      providers: [
+        ScrollXpService,
+        { provide: AchievementsService, useValue: achievements },
+      ],
+    });
+    service = TestBed.inject(ScrollXpService);
+  });
+
+  afterEach(() => service.ngOnDestroy());
+
+  // The 10 sections the service tracks; each is worth 10% XP.
+  const SECTIONS = [
+    'about', 'avatar-3d', 'skill', 'experience', 'metrics',
+    'publications', 'blogs', 'ai-quiz-game', 'education', 'operating-style',
+  ];
+
+  const view = (id: string) => (service as any).onSectionView(id);
+
+  it('starts at 0 XP and level 1 (Visitor)', () => {
+    expect(snapshot(service.xp$)).toBe(0);
+    expect(snapshot(service.level$)).toEqual({ level: 1, title: 'Visitor' });
+  });
+
+  it('awards 10% XP per unique section viewed', () => {
+    view('about');
+    expect(snapshot(service.xp$)).toBe(10);
+    view('skill');
+    expect(snapshot(service.xp$)).toBe(20);
+  });
+
+  it('ignores repeated views of the same section', () => {
+    view('about');
+    view('about');
+    view('about');
+    expect(snapshot(service.xp$)).toBe(10);
+  });
+
+  it('ignores sections it does not track', () => {
+    view('not-a-real-section');
+    expect(snapshot(service.xp$)).toBe(0);
+  });
+
+  it('never decreases XP', () => {
+    SECTIONS.forEach(view); // 100%
+    expect(snapshot(service.xp$)).toBe(100);
+    view('about'); // already counted
+    expect(snapshot(service.xp$)).toBe(100);
+  });
+
+  it('levels up and emits a LevelUpEvent at the 20% threshold (Explorer)', () => {
+    const events: LevelUpEvent[] = [];
+    service.levelUp$.subscribe(e => events.push(e));
+
+    view('about'); // 10% -> still level 1
+    expect(events.length).toBe(0);
+
+    view('skill'); // 20% -> Explorer
+    expect(snapshot(service.level$)).toEqual({ level: 2, title: 'Explorer' });
+    expect(events).toEqual([{ level: 2, title: 'Explorer' }]);
+  });
+
+  it('reaches Resume Master (level 6) at 100% XP', () => {
+    SECTIONS.forEach(view);
+    expect(snapshot(service.xp$)).toBe(100);
+    expect(snapshot(service.level$)).toEqual({ level: 6, title: 'Resume Master' });
+  });
+
+  it('tracks a speed run achievement once XP hits 100%', () => {
+    SECTIONS.forEach(view);
+    expect(achievements.trackSpeedRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call trackSpeedRun before reaching 100%', () => {
+    view('about');
+    view('skill');
+    expect(achievements.trackSpeedRun).not.toHaveBeenCalled();
+  });
+
+  describe('getLevelForXp', () => {
+    const levelFor = (xp: number) => (service as any).getLevelForXp(xp);
+
+    it('maps XP values to the correct level boundaries', () => {
+      expect(levelFor(0)).toBe(1);
+      expect(levelFor(19)).toBe(1);
+      expect(levelFor(20)).toBe(2);
+      expect(levelFor(40)).toBe(3);
+      expect(levelFor(60)).toBe(4);
+      expect(levelFor(80)).toBe(5);
+      expect(levelFor(100)).toBe(6);
+    });
+  });
+
+  it('cleans up its observer and scroll handler on destroy', () => {
+    const observer = (service as any).observer;
+    const disconnectSpy = observer ? spyOn(observer, 'disconnect').and.callThrough() : null;
+    const removeSpy = spyOn(window, 'removeEventListener').and.callThrough();
+
+    service.ngOnDestroy();
+
+    if (disconnectSpy) expect(disconnectSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalledWith('scroll', jasmine.any(Function));
+  });
+
+  function snapshot<T>(stream: { pipe: Function }): T {
+    let value!: T;
+    (stream as any).pipe(take(1)).subscribe((v: T) => (value = v));
+    return value;
+  }
+});

--- a/src/app/services/scroll-xp.service.ts
+++ b/src/app/services/scroll-xp.service.ts
@@ -23,7 +23,9 @@ export class ScrollXpService implements OnDestroy {
 
   private observer: IntersectionObserver | null = null;
   private viewedSections = new Set<string>();
-  private lastLevel = 0;
+  // Visitors begin at level 1 (Visitor), so treat that as the baseline and only
+  // emit a level-up event when they actually climb above it.
+  private lastLevel = 1;
   private scrollHandler: (() => void) | null = null;
 
   readonly xp$ = new BehaviorSubject<number>(0);

--- a/src/app/utils/text-utils.spec.ts
+++ b/src/app/utils/text-utils.spec.ts
@@ -1,0 +1,71 @@
+import { cleanTextForSpeech } from './text-utils';
+
+describe('cleanTextForSpeech', () => {
+  describe('guard clauses', () => {
+    it('returns an empty string for null/undefined/empty input', () => {
+      expect(cleanTextForSpeech(null as unknown as string)).toBe('');
+      expect(cleanTextForSpeech(undefined as unknown as string)).toBe('');
+      expect(cleanTextForSpeech('')).toBe('');
+    });
+
+    it('returns an empty string for non-string input', () => {
+      expect(cleanTextForSpeech(42 as unknown as string)).toBe('');
+      expect(cleanTextForSpeech({} as unknown as string)).toBe('');
+      expect(cleanTextForSpeech([] as unknown as string)).toBe('');
+    });
+  });
+
+  describe('markdown stripping', () => {
+    it('strips bold-italic, bold and italic markers but keeps the words', () => {
+      expect(cleanTextForSpeech('***wow***')).toBe('wow');
+      expect(cleanTextForSpeech('**bold**')).toBe('bold');
+      expect(cleanTextForSpeech('*italic*')).toBe('italic');
+      expect(cleanTextForSpeech('__bold__')).toBe('bold');
+      expect(cleanTextForSpeech('_italic_')).toBe('italic');
+    });
+
+    it('strips inline code markers', () => {
+      expect(cleanTextForSpeech('use `npm ci` now')).toBe('use npm ci now');
+    });
+
+    it('strips heading markers of every level', () => {
+      expect(cleanTextForSpeech('# H1')).toBe('H1');
+      expect(cleanTextForSpeech('###### H6')).toBe('H6');
+    });
+
+    it('keeps link text but drops the URL', () => {
+      expect(cleanTextForSpeech('see [my profile](https://example.com)')).toBe('see my profile');
+    });
+
+    it('drops the image source while keeping the alt text', () => {
+      expect(cleanTextForSpeech('![avatar](https://example.com/a.png)')).toContain('avatar');
+    });
+
+    it('removes leftover markdown punctuation characters', () => {
+      expect(cleanTextForSpeech('a ~ b [ c ] ( d )')).toBe('a b c d');
+    });
+  });
+
+  describe('emoji and whitespace handling', () => {
+    it('removes the documented set of emojis', () => {
+      expect(cleanTextForSpeech('Hi 👋 there 🤖')).toBe('Hi there');
+    });
+
+    it('collapses repeated whitespace and trims the result', () => {
+      expect(cleanTextForSpeech('  too    many\n\nspaces  ')).toBe('too many spaces');
+    });
+  });
+
+  describe('integration', () => {
+    it('cleans a realistic mixed-markdown assistant reply', () => {
+      const input = '## Summary\n\nCheck out **[node-actuator-lite](https://npmjs.com/x)** — it is `lightweight`! 🤖';
+      expect(cleanTextForSpeech(input)).toBe('Summary Check out node-actuator-lite — it is lightweight!');
+    });
+
+    it('is idempotent on already-clean text', () => {
+      const clean = 'This is a plain sentence.';
+      expect(cleanTextForSpeech(clean)).toBe(clean);
+      expect(cleanTextForSpeech(cleanTextForSpeech(clean))).toBe(clean);
+    });
+  });
+});


### PR DESCRIPTION
- Add Karma config and unit specs across components, services, config, and utils (92 tests passing)
- Fix ScrollXpService emitting a spurious level-up to the starting level (Visitor); seed lastLevel to 1 so events only fire when climbing above it
- Guard Avatar3dComponent against missing WebGL (e.g. headless CI) so the component initializes and chat stays usable without a GPU context
- Add Semantic Caching, MCP Servers, and Bedrock to the AI/ML skills with a gamified architecture-route map, and style the missing Salesforce quest badge