### PR TITLE
ci: dedupe workflow runs and restrict deploy to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [ master ]
   pull_request:
 
 permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy Portfolio to GitHub Pages
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 permissions:
   contents: read


### PR DESCRIPTION
- ci.yml: push trigger limited to master; branches run once via pull_request (previously push+pull_request both fired, causing duplicate runs per commit)
- deploy.yml: remove pull_request trigger so deploy/build only runs on master push