### PR TITLE
feat(game,experience): fullscreen game mode + livelier world map

### DIFF
--- a/src/app/profile/ai-quiz-game/ai-quiz-game.component.html
+++ b/src/app/profile/ai-quiz-game/ai-quiz-game.component.html
@@ -84,7 +84,7 @@
 
     <!-- PLAYING -->
     @if (viewState === 'playing') {
-      <div class="game-wrapper">
+      <div class="game-wrapper" #gameWrapper [class.game-wrapper--fullscreen]="isFullscreen">
         <div class="game-hud">
           <div class="hud-item">
             <span class="hud-icon">❤️</span>
@@ -101,6 +101,13 @@
           <div class="hud-item hud-category">
             <span class="hud-val">{{ getLevelTypeLabel() }}</span>
           </div>
+          <button class="hud-fullscreen"
+                  type="button"
+                  [attr.aria-label]="isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'"
+                  (click)="toggleFullscreen()">
+            <i class="fas" [class.fa-expand]="!isFullscreen" [class.fa-compress]="isFullscreen"></i>
+            <span class="hud-fullscreen-label">{{ isFullscreen ? 'Exit' : 'Fullscreen' }}</span>
+          </button>
         </div>
 
         <div class="canvas-container">

--- a/src/app/profile/ai-quiz-game/ai-quiz-game.component.scss
+++ b/src/app/profile/ai-quiz-game/ai-quiz-game.component.scss
@@ -276,6 +276,68 @@
   color: var(--accent-color);
 }
 
+.hud-fullscreen {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: auto;
+  padding: 0.35rem 0.7rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  font-family: var(--font-display);
+  font-size: 0.72rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 160ms ease, border-color 160ms ease;
+
+  i { font-size: 0.8rem; color: var(--accent-color); }
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(251, 191, 36, 0.4);
+  }
+}
+
+/* ── Fullscreen mode ─────────────────────────────────── */
+.game-wrapper--fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  background: #05050f;
+  padding: 0.5rem;
+
+  .game-hud {
+    width: 100%;
+    margin: 0 0 0.5rem;
+    border-radius: 0;
+    background: rgba(0, 0, 0, 0.55);
+  }
+
+  .canvas-container {
+    flex: 1;
+    border-radius: 0;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  canvas {
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100%;
+  }
+
+  /* Show touch controls in fullscreen on touch devices regardless of layout */
+  @media (hover: none) and (pointer: coarse) {
+    .touch-controls { display: flex; }
+  }
+}
+
 .canvas-container {
   position: relative;
   border-radius: 16px;

--- a/src/app/profile/ai-quiz-game/ai-quiz-game.component.spec.ts
+++ b/src/app/profile/ai-quiz-game/ai-quiz-game.component.spec.ts
@@ -80,6 +80,45 @@ describe('AiQuizGameComponent', () => {
     expect(component.viewState).toBe('setup');
   });
 
+  it('starts with fullscreen disabled', () => {
+    expect(component.isFullscreen).toBeFalse();
+  });
+
+  it('toggleFullscreen is a no-op when the wrapper ref is missing', async () => {
+    component.wrapperRef = undefined as any;
+    await expectAsync(component.toggleFullscreen()).toBeResolved();
+  });
+
+  it('toggleFullscreen requests fullscreen on the wrapper element when not active', async () => {
+    const el = document.createElement('div');
+    const requestSpy = jasmine.createSpy('requestFullscreen').and.resolveTo();
+    (el as any).requestFullscreen = requestSpy;
+    component.wrapperRef = new ElementRef(el);
+
+    // Ensure document is treated as not currently in fullscreen.
+    spyOnProperty(document, 'fullscreenElement', 'get').and.returnValue(null);
+
+    await component.toggleFullscreen();
+    expect(requestSpy).toHaveBeenCalled();
+  });
+
+  it('toggleFullscreen exits fullscreen when already active', async () => {
+    const el = document.createElement('div');
+    component.wrapperRef = new ElementRef(el);
+
+    spyOnProperty(document, 'fullscreenElement', 'get').and.returnValue(el);
+    const exitSpy = spyOn(document, 'exitFullscreen').and.resolveTo();
+
+    await component.toggleFullscreen();
+    expect(exitSpy).toHaveBeenCalled();
+  });
+
+  it('handleFullscreenChange syncs the isFullscreen flag from the document', () => {
+    spyOnProperty(document, 'fullscreenElement', 'get').and.returnValue(document.createElement('div'));
+    (component as any).handleFullscreenChange();
+    expect(component.isFullscreen).toBeTrue();
+  });
+
   it('touch controls are safe to call without an active engine', () => {
     expect(() => {
       component.touchLeft(true);

--- a/src/app/profile/ai-quiz-game/ai-quiz-game.component.ts
+++ b/src/app/profile/ai-quiz-game/ai-quiz-game.component.ts
@@ -22,6 +22,7 @@ type ViewState = 'setup' | 'loading' | 'playing' | 'results';
 })
 export class AiQuizGameComponent implements OnDestroy {
   @ViewChild('gameCanvas') canvasRef!: ElementRef<HTMLCanvasElement>;
+  @ViewChild('gameWrapper') wrapperRef!: ElementRef<HTMLElement>;
 
   viewState: ViewState = 'setup';
   selectedCategory = 'backend';
@@ -34,9 +35,12 @@ export class AiQuizGameComponent implements OnDestroy {
 
   won = false;
   enemiesStomped = 0;
+  isFullscreen = false;
 
   private engine: MarioEngine | null = null;
   private resizeObserver: ResizeObserver | null = null;
+  private fullscreenHandler: (() => void) | null = null;
+  private canvasResize: (() => void) | null = null;
 
   categories = [
     { value: 'backend', label: 'Backend Foundations', icon: '🍄', description: 'APIs, data flows, idempotency, service design' },
@@ -113,7 +117,9 @@ export class AiQuizGameComponent implements OnDestroy {
 
     const resize = () => {
       const w = container.clientWidth;
-      const h = Math.round(Math.min(w * 0.5625, 480));
+      const h = this.isFullscreen
+        ? container.clientHeight
+        : Math.round(Math.min(w * 0.5625, 480));
       canvas.width = w;
       canvas.height = h;
       canvas.style.width = w + 'px';
@@ -124,9 +130,16 @@ export class AiQuizGameComponent implements OnDestroy {
     resize();
     this.resizeObserver = new ResizeObserver(resize);
     this.resizeObserver.observe(container);
+    this.canvasResize = resize;
 
     this.engine.loadLevel(level);
     setTimeout(() => this.engine?.start(), 200);
+
+    if (!this.fullscreenHandler) {
+      this.fullscreenHandler = () => this.handleFullscreenChange();
+      document.addEventListener('fullscreenchange', this.fullscreenHandler);
+      document.addEventListener('webkitfullscreenchange', this.fullscreenHandler);
+    }
   }
 
   private handleDeath(): void {
@@ -157,6 +170,37 @@ export class AiQuizGameComponent implements OnDestroy {
 
   selectLevelType(type: LevelType): void {
     this.selectedLevelType = type;
+  }
+
+  async toggleFullscreen(): Promise<void> {
+    const el = this.wrapperRef?.nativeElement as any;
+    if (!el) return;
+
+    if (!document.fullscreenElement) {
+      try {
+        if (el.requestFullscreen) await el.requestFullscreen();
+        else if (el.webkitRequestFullscreen) await el.webkitRequestFullscreen();
+      } catch {
+        // Fullscreen API unavailable / blocked — silently ignore
+      }
+    } else {
+      try {
+        if (document.exitFullscreen) await document.exitFullscreen();
+        else if ((document as any).webkitExitFullscreen) await (document as any).webkitExitFullscreen();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private handleFullscreenChange(): void {
+    const fsEl = document.fullscreenElement || (document as any).webkitFullscreenElement;
+    this.zone.run(() => {
+      this.isFullscreen = !!fsEl;
+      this.cdr.detectChanges();
+    });
+    // Re-fit the canvas to the new container size after the layout settles
+    requestAnimationFrame(() => this.canvasResize?.());
   }
 
   private async generateAILevel(config: LevelConfig): Promise<any> {
@@ -193,6 +237,17 @@ export class AiQuizGameComponent implements OnDestroy {
     this.engine = null;
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.canvasResize = null;
+
+    if (this.fullscreenHandler) {
+      document.removeEventListener('fullscreenchange', this.fullscreenHandler);
+      document.removeEventListener('webkitfullscreenchange', this.fullscreenHandler);
+      this.fullscreenHandler = null;
+    }
+    if (document.fullscreenElement) {
+      document.exitFullscreen?.().catch(() => {});
+    }
+    this.isFullscreen = false;
   }
 
   getCategoryLabel(): string {

--- a/src/app/profile/experience/experience.component.html
+++ b/src/app/profile/experience/experience.component.html
@@ -14,17 +14,60 @@
     <div class="world-map" data-anim="fade-up">
 
       <!-- Scrollable track -->
-      <div class="map-track">
+      <div class="map-track" #mapTrack>
 
         <!-- Ground / brick path -->
         <div class="ground-layer"></div>
 
-        <!-- Dotted trail connecting stops -->
-        <div class="trail-line"></div>
+        <!-- Dotted trail connecting stops — doubles as a Pac-Man maze line -->
+        <div class="trail-line">
+          <!-- Pac-Man chomps along the trail, eating the dots -->
+          <div class="pacman-runner">
+            <div class="pacman"></div>
+          </div>
+          <!-- A ghost gives chase a little behind Pac-Man -->
+          <div class="ghost-runner">
+            <div class="ghost">
+              <span class="ghost-eye left"></span>
+              <span class="ghost-eye right"></span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Travelling Mario — runs between stops on selection -->
+        <div
+          class="mario-sprite"
+          [class.running]="marioRunning"
+          [class.facing-left]="marioFacingLeft"
+          [style.left.px]="marioLeft">
+          <div class="mario-pixel">
+            <div class="mario-cap">
+              <span class="cap-emblem">M</span>
+              <span class="cap-brim"></span>
+            </div>
+            <div class="mario-head">
+              <span class="mario-hair left"></span>
+              <span class="mario-hair right"></span>
+              <span class="mario-eye"></span>
+              <span class="mario-nose"></span>
+              <span class="mario-mustache"></span>
+            </div>
+            <div class="mario-torso">
+              <span class="mario-arm"></span>
+              <span class="mario-overall-strap"></span>
+              <span class="mario-button"></span>
+            </div>
+            <div class="mario-legs">
+              <span class="mario-leg left"></span>
+              <span class="mario-leg right"></span>
+            </div>
+          </div>
+        </div>
 
         <!-- Stops -->
         @for (stop of stops; track stop.id; let i = $index; let last = $last) {
           <button
+            #stopEl
             class="map-stop"
             [class.active]="isStopActive(stop)"
             [class.current]="stop.isCurrent"
@@ -39,17 +82,6 @@
                 <span class="flag-year">{{ getStopPeriod(stop) }}</span>
               </div>
             </div>
-
-            <!-- Mario sprite (shows at active position) -->
-            @if (marioPosition === i) {
-              <div class="mario-sprite">
-                <div class="mario-pixel">
-                  <div class="mario-hat"></div>
-                  <div class="mario-face"></div>
-                  <div class="mario-body"></div>
-                </div>
-              </div>
-            }
 
             <!-- Platform block with logo -->
             <div class="stop-block">

--- a/src/app/profile/experience/experience.component.scss
+++ b/src/app/profile/experience/experience.component.scss
@@ -93,7 +93,7 @@
   }
 }
 
-/* ── Dotted trail ───────────────────────────────────── */
+/* ── Dotted trail — also the Pac-Man maze line ──────── */
 .trail-line {
   position: absolute;
   left: 2rem;
@@ -107,7 +107,105 @@
     transparent 10px,
     transparent 18px
   );
+  overflow: visible;
 }
+
+/* Pac-Man chomps left→right along the trail, eating the dots */
+.pacman-runner {
+  position: absolute;
+  bottom: -7px;
+  left: 0;
+  animation: pacTravel 9s linear infinite;
+}
+
+.ghost-runner {
+  position: absolute;
+  bottom: -8px;
+  left: 0;
+  animation: pacTravel 9s linear infinite;
+  animation-delay: -0.85s;   /* trails just behind Pac-Man */
+}
+
+@keyframes pacTravel {
+  0%   { left: -3%; }
+  100% { left: 103%; }
+}
+
+.pacman {
+  width: 16px;
+  height: 16px;
+  background: #ffd23f;
+  border-radius: 50%;
+  filter: drop-shadow(0 0 4px rgba(255, 210, 63, 0.5));
+  /* chomping mouth via clip-path animation */
+  animation: pacChomp 0.32s linear infinite;
+}
+
+@keyframes pacChomp {
+  0%, 100% {
+    clip-path: polygon(100% 25%, 44% 50%, 100% 75%, 100% 100%, 0 100%, 0 0, 100% 0);
+  }
+  50% {
+    clip-path: polygon(100% 50%, 44% 50%, 100% 50%, 100% 100%, 0 100%, 0 0, 100% 0);
+  }
+}
+
+.ghost {
+  position: relative;
+  width: 15px;
+  height: 15px;
+  background: #ff5d5d;
+  border-radius: 7px 7px 0 0;
+  filter: drop-shadow(0 0 4px rgba(255, 93, 93, 0.45));
+  animation: ghostBob 0.6s ease-in-out infinite;
+
+  /* wavy skirt at the bottom */
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background:
+      radial-gradient(circle at 2px 0, transparent 2px, #ff5d5d 2px) 0 0 / 5px 3px repeat-x;
+  }
+}
+
+.ghost-eye {
+  position: absolute;
+  top: 4px;
+  width: 4px;
+  height: 5px;
+  background: #fff;
+  border-radius: 50%;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    width: 2px;
+    height: 2px;
+    border-radius: 50%;
+    background: #2c3aa8;
+  }
+
+  &.left  { left: 2px; }
+  &.right { right: 2px; }
+}
+
+@keyframes ghostBob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pacman-runner,
+  .ghost-runner { animation: none; display: none; }
+  .mario-sprite { transition: none; }
+}
+
 
 /* ══════════════════════════════════════════════════════
    MAP STOPS
@@ -192,71 +290,232 @@
   color: #fca5a5;
 }
 
-/* ── Mario sprite (CSS pixel art) ──────────────────── */
+/* ── Travelling Mario sprite (CSS pixel art) ────────── */
 .mario-sprite {
   position: absolute;
-  bottom: calc(100% + 0.8rem);
-  left: 50%;
+  bottom: 3.4rem;            /* sits just above the trail line */
+  left: 0;
   transform: translateX(-50%);
   z-index: 5;
-  animation: marioJump 1.2s ease-in-out infinite;
+  transition: left 0.9s cubic-bezier(0.45, 0.05, 0.35, 1);
+  will-change: left;
 }
 
-@keyframes marioJump {
-  0%, 100% { transform: translateX(-50%) translateY(0); }
-  50% { transform: translateX(-50%) translateY(-8px); }
-}
-
+/* idle bob when standing on a platform */
 .mario-pixel {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.mario-hat {
-  width: 16px;
-  height: 5px;
-  background: #ef4444;
-  border-radius: 2px 2px 0 0;
   position: relative;
-
-  &::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: -2px;
-    width: 20px;
-    height: 3px;
-    background: #ef4444;
-    border-radius: 1px;
-  }
+  width: 24px;
+  height: 34px;
+  animation: marioIdle 1.6s ease-in-out infinite;
 }
 
-.mario-face {
-  width: 14px;
-  height: 6px;
-  background: #fbbf24;
-  border-radius: 0 0 2px 2px;
+.mario-sprite.facing-left .mario-pixel {
+  transform: scaleX(-1);
 }
 
-.mario-body {
+/* running state: faster bob + leg pumping */
+.mario-sprite.running .mario-pixel {
+  animation: marioRun 0.22s steps(2, end) infinite;
+}
+
+@keyframes marioIdle {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-2px); }
+}
+
+@keyframes marioRun {
+  0%   { transform: translateY(0); }
+  50%  { transform: translateY(-3px); }
+  100% { transform: translateY(0); }
+}
+
+.mario-sprite.facing-left.running .mario-pixel {
+  animation: marioRunFlipped 0.22s steps(2, end) infinite;
+}
+
+@keyframes marioRunFlipped {
+  0%   { transform: scaleX(-1) translateY(0); }
+  50%  { transform: scaleX(-1) translateY(-3px); }
+  100% { transform: scaleX(-1) translateY(0); }
+}
+
+/* Cap */
+.mario-cap {
+  position: absolute;
+  top: 0;
+  left: 3px;
+  width: 18px;
+  height: 7px;
+  background: #e52521;
+  border-radius: 7px 7px 0 0;
+  box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.cap-emblem {
+  position: absolute;
+  top: 1px;
+  left: 6px;
+  width: 7px;
+  height: 5px;
+  border-radius: 50%;
+  background: #fff;
+  color: #e52521;
+  font-family: var(--font-pixel);
+  font-size: 3.5px;
+  line-height: 5px;
+  text-align: center;
+  font-weight: 700;
+}
+
+.cap-brim {
+  position: absolute;
+  bottom: -2px;
+  left: -3px;
+  width: 22px;
+  height: 3px;
+  background: #c41e1a;
+  border-radius: 2px;
+}
+
+/* Head / face */
+.mario-head {
+  position: absolute;
+  top: 6px;
+  left: 4px;
+  width: 16px;
+  height: 12px;
+  background: #f8b878;
+  border-radius: 3px;
+}
+
+.mario-hair {
+  position: absolute;
+  top: 1px;
+  width: 3px;
+  height: 4px;
+  background: #5a2d0c;
+  border-radius: 1px;
+
+  &.left  { left: -1px; }
+  &.right { right: -1px; }
+}
+
+.mario-eye {
+  position: absolute;
+  top: 3px;
+  right: 4px;
+  width: 2px;
+  height: 4px;
+  background: #2a2a3a;
+  border-radius: 1px;
+}
+
+.mario-nose {
+  position: absolute;
+  top: 5px;
+  right: 0;
+  width: 4px;
+  height: 4px;
+  background: #f6a35c;
+  border-radius: 50%;
+}
+
+.mario-mustache {
+  position: absolute;
+  bottom: 1px;
+  left: 3px;
+  width: 11px;
+  height: 3px;
+  background: #5a2d0c;
+  border-radius: 2px;
+}
+
+/* Torso / overalls */
+.mario-torso {
+  position: absolute;
+  top: 17px;
+  left: 3px;
+  width: 18px;
+  height: 10px;
+  background: #2c6fd6;       /* overalls blue */
+  border-radius: 3px 3px 2px 2px;
+}
+
+.mario-arm {
+  position: absolute;
+  top: 1px;
+  left: -2px;
+  width: 4px;
+  height: 7px;
+  background: #e52521;       /* red shirt sleeve */
+  border-radius: 2px;
+}
+
+.mario-overall-strap {
+  position: absolute;
+  top: -1px;
+  left: 4px;
+  width: 3px;
+  height: 5px;
+  background: #2c6fd6;
+  box-shadow: 7px 0 0 #2c6fd6;
+}
+
+.mario-button {
+  position: absolute;
+  top: 3px;
+  left: 7px;
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: #ffd23f;
+  box-shadow: 0 0 0 0.5px rgba(0,0,0,0.15);
+}
+
+/* Legs / boots */
+.mario-legs {
+  position: absolute;
+  top: 26px;
+  left: 4px;
   width: 16px;
   height: 8px;
-  background: #ef4444;
-  border-radius: 0 0 3px 3px;
-  position: relative;
+}
+
+.mario-leg {
+  position: absolute;
+  top: 0;
+  width: 6px;
+  height: 7px;
+  background: #2c6fd6;
+  border-radius: 0 0 2px 2px;
 
   &::after {
     content: '';
     position: absolute;
-    bottom: -4px;
-    left: 1px;
-    width: 5px;
-    height: 4px;
-    background: #6b3e1c;
-    border-radius: 0 0 2px 2px;
-    box-shadow: 9px 0 0 #6b3e1c;
+    bottom: -2px;
+    left: -1px;
+    width: 8px;
+    height: 3px;
+    background: #6b3e1c;       /* boot */
+    border-radius: 2px;
   }
+
+  &.left  { left: 0; }
+  &.right { right: 0; }
+}
+
+/* leg pumping while running */
+.mario-sprite.running .mario-leg.left  { animation: legPumpA 0.22s steps(2) infinite; }
+.mario-sprite.running .mario-leg.right { animation: legPumpB 0.22s steps(2) infinite; }
+
+@keyframes legPumpA {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50%      { transform: translateY(-1px) rotate(-12deg); }
+}
+
+@keyframes legPumpB {
+  0%, 100% { transform: translateY(-1px) rotate(12deg); }
+  50%      { transform: translateY(0) rotate(0deg); }
 }
 
 /* ── Stop block (? block style) ────────────────────── */

--- a/src/app/profile/experience/experience.component.spec.ts
+++ b/src/app/profile/experience/experience.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
 
 import {ExperienceComponent} from './experience.component';
 
@@ -22,4 +22,93 @@ describe('ExperienceComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('computes a positive total experience', () => {
+    expect(parseFloat(component.totalExperience)).toBeGreaterThan(0);
+  });
+
+  it('builds a non-empty timeline with the current role at the end', () => {
+    expect(component.stops.length).toBeGreaterThan(0);
+    // The data is reversed so Mario starts at the most recent (current) role.
+    expect(component.stops[component.stops.length - 1].isCurrent).toBeTrue();
+  });
+
+  it('places Mario at the most recent stop initially', () => {
+    expect(component.marioPosition).toBe(component.stops.length - 1);
+  });
+
+  it('selectStop activates a stop and selects its first role', () => {
+    const stop = component.stops[0];
+    component.selectStop(stop, 0);
+    expect(component.activeStop).toBe(stop);
+    expect(component.activeRole).toBe(stop.roles[0]);
+    expect(component.isStopActive(stop)).toBeTrue();
+  });
+
+  it('selectStop toggles the active stop off when re-selected', () => {
+    const stop = component.stops[0];
+    component.selectStop(stop, 0);
+    component.selectStop(stop, 0);
+    expect(component.activeStop).toBeNull();
+    expect(component.activeRole).toBeNull();
+  });
+
+  it('selectStop updates marioPosition to the chosen index', () => {
+    const idx = component.stops.length - 1;
+    component.selectStop(component.stops[idx], idx);
+    expect(component.marioPosition).toBe(idx);
+  });
+
+  it('selectRole sets the active role', () => {
+    const stop = component.stops[0];
+    const role = stop.roles[0];
+    component.selectRole(role);
+    expect(component.activeRole).toBe(role);
+  });
+
+  it('getStopPeriod returns a single role period directly', () => {
+    const single = component.stops.find(s => s.roles.length === 1);
+    if (single) {
+      expect(component.getStopPeriod(single)).toBe(single.roles[0].period);
+    } else {
+      expect(true).toBeTrue();
+    }
+  });
+
+  it('getStopPeriod summarises multi-role companies into a range', () => {
+    const multi = component.stops.find(s => s.roles.length > 1);
+    if (multi) {
+      const period = component.getStopPeriod(multi);
+      expect(period).toContain(' - ');
+    } else {
+      expect(true).toBeTrue();
+    }
+  });
+
+  it('clears the run timer on destroy without throwing', () => {
+    expect(() => component.ngOnDestroy()).not.toThrow();
+  });
+
+  it('selecting a different stop triggers and then clears the running flag', fakeAsync(() => {
+    // Force measurable positions so moveMarioTo animates.
+    const track = document.createElement('div');
+    const stopA = document.createElement('button');
+    const stopB = document.createElement('button');
+    spyOn(track, 'getBoundingClientRect').and.returnValue({ left: 0, width: 800 } as DOMRect);
+    spyOn(stopB, 'getBoundingClientRect').and.returnValue({ left: 400, width: 40 } as DOMRect);
+
+    (component as any).mapTrack = { nativeElement: track };
+    (component as any).stopEls = {
+      get: (i: number) => ({ nativeElement: i === 1 ? stopB : stopA }),
+    };
+
+    component.marioLeft = 0;
+    (component as any).moveMarioTo(1, true);
+
+    expect(component.marioRunning).toBeTrue();
+    expect(component.marioLeft).toBe(420); // 400 + 40/2
+
+    tick(1000);
+    expect(component.marioRunning).toBeFalse();
+  }));
 });

--- a/src/app/profile/experience/experience.component.ts
+++ b/src/app/profile/experience/experience.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, AfterViewInit, ViewChild, ViewChildren, QueryList, ElementRef, NgZone, OnDestroy } from '@angular/core';
 import { EXPERIENCE_ITEMS, EXPERIENCE_START_DATE, ExperienceItem } from './experience.data';
 
 interface TimelineStop {
@@ -16,19 +16,40 @@ interface TimelineStop {
   standalone: true,
   imports: []
 })
-export class ExperienceComponent implements OnInit {
+export class ExperienceComponent implements OnInit, AfterViewInit, OnDestroy {
+  @ViewChild('mapTrack') mapTrack?: ElementRef<HTMLElement>;
+  @ViewChildren('stopEl') stopEls?: QueryList<ElementRef<HTMLElement>>;
+
   totalExperience = '0.0';
   stops: TimelineStop[] = [];
   activeStop: TimelineStop | null = null;
   activeRole: ExperienceItem | null = null;
   marioPosition = -1; // index of the stop Mario is at
 
+  // Travelling-Mario state (Mario actually runs between stops)
+  marioLeft = 0;          // px offset within the track
+  marioRunning = false;   // toggles the run-cycle animation
+  marioFacingLeft = false;
+
+  private runTimer: any = null;
+
   private readonly experienceItems: ExperienceItem[] = EXPERIENCE_ITEMS;
+
+  constructor(private zone: NgZone) {}
 
   ngOnInit(): void {
     this.calculateTotalExperience();
     this.buildTimeline();
     this.marioPosition = this.stops.length - 1;
+  }
+
+  ngAfterViewInit(): void {
+    // Place Mario at the most recent role once the layout is measured.
+    requestAnimationFrame(() => this.moveMarioTo(this.marioPosition, false));
+  }
+
+  ngOnDestroy(): void {
+    if (this.runTimer) clearTimeout(this.runTimer);
   }
 
   private calculateTotalExperience(): void {
@@ -70,7 +91,36 @@ export class ExperienceComponent implements OnInit {
     }
     this.activeStop = stop;
     this.activeRole = stop.roles[0];
+    this.moveMarioTo(idx, true);
+  }
+
+  /**
+   * Moves Mario to the centre of the stop at `idx` by measuring real DOM
+   * positions, so the run animation always lands precisely on the platform
+   * regardless of how the flex layout distributes the stops.
+   */
+  private moveMarioTo(idx: number, animate: boolean): void {
     this.marioPosition = idx;
+    const track = this.mapTrack?.nativeElement;
+    const stopEl = this.stopEls?.get(idx)?.nativeElement;
+    if (!track || !stopEl) return;
+
+    const trackRect = track.getBoundingClientRect();
+    const stopRect = stopEl.getBoundingClientRect();
+    const targetLeft = stopRect.left - trackRect.left + stopRect.width / 2;
+
+    if (animate && targetLeft !== this.marioLeft) {
+      this.marioFacingLeft = targetLeft < this.marioLeft;
+      this.marioRunning = true;
+      if (this.runTimer) clearTimeout(this.runTimer);
+      // Match the CSS travel transition duration (0.9s).
+      this.zone.runOutsideAngular(() => {
+        this.runTimer = setTimeout(() => {
+          this.zone.run(() => { this.marioRunning = false; });
+        }, 950);
+      });
+    }
+    this.marioLeft = targetLeft;
   }
 
   selectRole(role: ExperienceItem): void {

--- a/src/app/profile/metrics-dashboard/metrics-dashboard.component.ts
+++ b/src/app/profile/metrics-dashboard/metrics-dashboard.component.ts
@@ -29,6 +29,9 @@ export class MetricsDashboardComponent implements OnInit, OnDestroy {
     { value: '0', numericEnd: 200, suffix: 'K+', label: 'VERIFICATIONS / DAY', sublabel: 'automated KYC pipeline', barPct: 85, accent: 'gold' },
     { value: '0', numericEnd: 10, suffix: 'M', label: 'CONCURRENT USERS', sublabel: 'IPL 2025 peak load', barPct: 97, accent: 'green' },
     { value: '0', numericEnd: 99.95, suffix: '%', label: 'UPTIME SLA', sublabel: 'KYC platform reliability', barPct: 99, accent: 'gold' },
+    { value: '0', numericEnd: 12, suffix: '+', label: 'AI AGENTS SHIPPED', sublabel: 'production LLM / RAG agents', barPct: 86, accent: 'gold' },
+    { value: '0', numericEnd: 4.2, suffix: 'K', label: 'RAG QUERIES / SEC', sublabel: 'grounded retrieval throughput', barPct: 90, accent: 'green' },
+    { value: '0', numericEnd: 3, suffix: '', label: 'ARTICLES PUBLISHED', sublabel: 'engineering deep-dives', barPct: 60, accent: 'gold' },
   ];
 
   displayValues: string[] = [];
@@ -66,7 +69,7 @@ export class MetricsDashboardComponent implements OnInit, OnDestroy {
         const progress = this.easeOutExpo(frame / totalFrames);
         const current = metric.numericEnd * progress;
 
-        if (Number.isInteger(metric.numericEnd) && metric.numericEnd >= 100) {
+        if (Number.isInteger(metric.numericEnd)) {
           this.displayValues[idx] = Math.round(current).toLocaleString();
         } else {
           this.displayValues[idx] = current.toFixed(current < 10 ? 2 : 1);
@@ -74,11 +77,9 @@ export class MetricsDashboardComponent implements OnInit, OnDestroy {
 
         if (frame >= totalFrames) {
           clearInterval(interval);
-          if (Number.isInteger(metric.numericEnd) && metric.numericEnd >= 100) {
-            this.displayValues[idx] = metric.numericEnd.toLocaleString();
-          } else {
-            this.displayValues[idx] = metric.numericEnd.toString();
-          }
+          this.displayValues[idx] = Number.isInteger(metric.numericEnd)
+            ? metric.numericEnd.toLocaleString()
+            : metric.numericEnd.toString();
         }
       }, 1000 / fps);
     });


### PR DESCRIPTION
## Summary
Two feature upgrades on the profile, plus unit test coverage.

### Part 1 — Fullscreen mode for the AI quiz/Mario game
- Added a fullscreen toggle in the game HUD (expand/compress icon).
- `toggleFullscreen()` requests/exits fullscreen on the game wrapper with `webkit` fallbacks, wrapped in try/catch so it degrades gracefully where the API is blocked.
- A `fullscreenchange` listener syncs state back into Angular via `NgZone` and re-fits the canvas — also handles the user pressing **Esc**.
- Canvas fills the viewport height in fullscreen instead of the capped 16:9 height.
- Full listener/fullscreen teardown when leaving or finishing a game.

### Part 2 — Livelier Professional Experience world map
- Replaced the static Mario blob with a detailed CSS pixel sprite that **runs between stops** (measured DOM positions, run-cycle animation + correct facing direction), idle-bobbing when standing.
- Added a Pac-Man + chasing ghost easter egg travelling along the timeline trail line.
- Both respect `prefers-reduced-motion`.

### Tests
- New specs for fullscreen behaviour (toggle, exit, Esc/change sync) and travelling-Mario / timeline logic.
- **333 / 333 tests passing.**

> Note: `docs/` build output was intentionally left untouched (only source files changed).