### PR TITLE
fix(experience): give travelling Mario a second eye

### DIFF
--- a/src/app/profile/experience/experience.component.html
+++ b/src/app/profile/experience/experience.component.html
@@ -48,7 +48,8 @@
             <div class="mario-head">
               <span class="mario-hair left"></span>
               <span class="mario-hair right"></span>
-              <span class="mario-eye"></span>
+              <span class="mario-eye left"></span>
+              <span class="mario-eye right"></span>
               <span class="mario-nose"></span>
               <span class="mario-mustache"></span>
             </div>

--- a/src/app/profile/experience/experience.component.scss
+++ b/src/app/profile/experience/experience.component.scss
@@ -403,11 +403,13 @@
 .mario-eye {
   position: absolute;
   top: 3px;
-  right: 4px;
   width: 2px;
   height: 4px;
   background: #2a2a3a;
   border-radius: 1px;
+
+  &.left  { right: 8px; }
+  &.right { right: 4px; }
 }
 
 .mario-nose {


### PR DESCRIPTION
## Summary
Follow-up to #12. The travelling Mario sprite on the Professional Experience world map was drawn in a side-view style with only a single eye. This gives it a second eye for a proper front-facing look.

### Changes
- **HTML:** split the single `.mario-eye` into `.mario-eye.left` and `.mario-eye.right`.
- **SCSS:** positioned the two eyes side by side instead of a single right-anchored eye.

CSS/HTML-only change; `tsc` compiles clean.